### PR TITLE
Show errors and stop function.create when ClientError

### DIFF
--- a/kappa/function.py
+++ b/kappa/function.py
@@ -395,6 +395,9 @@ class Function(object):
                     if 'InvalidParameterValueException' in str(e):
                         LOG.debug('Role is not ready, waiting')
                         time.sleep(2)
+                    else:
+                        LOG.debug(str(e))
+                        ready = True
                 except Exception:
                     LOG.exception('Unable to upload zip file')
                     ready = True


### PR DESCRIPTION
The previous code checked only for one error and if some validation error occurred on AWS API 
then an infinite loop was happening.

I was wondering if I can create test this somehow?

ps: I am not a Python developer :(